### PR TITLE
Fix multiple master (globalservers 0) support & re-added vid_x/ypos cvars (sort of) 

### DIFF
--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -197,7 +197,7 @@ void CG_ParseServerinfo( void ) {
 	else if (!Q_stricmpn(Info_ValueForKey(info, "gamename"), "japro", 5)) {
 		cgs.isJAPro = qtrue;
 		cgs.jcinfo = atoi (Info_ValueForKey (info, "jcinfo" ));//[JAPRO - Clientside - All - Add gamename variable to get jcinfo from japro servers]
-		trap_Cvar_Set("ui_isJAPro", "1");
+		trap->Cvar_Set("ui_isJAPro", "1");
 
 		cgs.hookpull = atoi (Info_ValueForKey (info, "g_hookStrength" ));//[JAPRO - Clientside - All - Add gamename variable to get jcinfo from japro servers]
 		if (cgs.hookpull == 0)

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -194,5 +194,5 @@ XCVAR_DEF( ui_tm2_c4_cnt,						"0",					NULL,					CVAR_ROM|CVAR_INTERNAL )
 XCVAR_DEF( ui_tm2_c5_cnt,						"0",					NULL,					CVAR_ROM|CVAR_INTERNAL )
 XCVAR_DEF( ui_tm2_cnt,							"0",					NULL,					CVAR_ROM|CVAR_INTERNAL )
 XCVAR_DEF( ui_tm3_cnt,							"0",					NULL,					CVAR_ROM|CVAR_INTERNAL )
-XCVAR_DEF( ui_isJAPro,							"0",					NULL,					0 )
+XCVAR_DEF( ui_isJAPro,							"0",					NULL,					CVAR_ROM|CVAR_INTERNAL )
 #undef XCVAR_DEF

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -3291,7 +3291,7 @@ static void CL_SetServerInfo(serverInfo_t *server, const char *info, int ping) {
 	if (server) {
 		if (info) {
 			char * filteredHostName = Info_ValueForKey(info, "hostname");
-			if (Q_stricmp(filteredHostName, "")) { Q_strstrip(filteredHostName, "€¬", NULL); }
+			if (Q_stricmp(filteredHostName, "")) { Q_strstrip(filteredHostName, "ï¿½ï¿½", NULL); }
 			//server->clients = atoi(Info_ValueForKey(info, "clients"));
 			Q_strncpyz(server->hostName, filteredHostName, MAX_NAME_LENGTH);
 			Q_strncpyz(server->mapName, Info_ValueForKey(info, "mapname"), MAX_NAME_LENGTH);
@@ -3755,12 +3755,12 @@ void CL_GlobalServers_f( void ) {
 		return;
 	}
 
-	Com_sprintf( command, sizeof(command), "sv_master%d", masterNum + 1 );
+	Com_sprintf( command, sizeof(command), "sv_master%d", masterNum );
 	masteraddress = Cvar_VariableString( command );
 
 	if ( !*masteraddress )
 	{
-		Com_Printf( "CL_GlobalServers_f: Error: No master server address given.\n" );
+		Com_Printf( "CL_GlobalServers_f: Error: No master server address given for %s.\n" ,command );
 		return;
 	}
 

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -3291,7 +3291,7 @@ static void CL_SetServerInfo(serverInfo_t *server, const char *info, int ping) {
 	if (server) {
 		if (info) {
 			char * filteredHostName = Info_ValueForKey(info, "hostname");
-			if (Q_stricmp(filteredHostName, "")) { Q_strstrip(filteredHostName, "��", NULL); }
+			if (Q_stricmp(filteredHostName, "")) { Q_strstrip(filteredHostName, "¬", NULL); }
 			//server->clients = atoi(Info_ValueForKey(info, "clients"));
 			Q_strncpyz(server->hostName, filteredHostName, MAX_NAME_LENGTH);
 			Q_strncpyz(server->mapName, Info_ValueForKey(info, "mapname"), MAX_NAME_LENGTH);

--- a/codemp/rd-dedicated/tr_init.cpp
+++ b/codemp/rd-dedicated/tr_init.cpp
@@ -344,7 +344,7 @@ void R_Register( void )
 	r_mode								= ri->Cvar_Get( "r_mode",							"4",						CVAR_ARCHIVE|CVAR_LATCH, "" );
 	r_fullscreen						= ri->Cvar_Get( "r_fullscreen",						"0",						CVAR_ARCHIVE|CVAR_LATCH, "" );
 	r_noborder							= ri->Cvar_Get( "r_noborder",						"0",						CVAR_ARCHIVE|CVAR_LATCH, "" );
-	r_centerWindow						= ri->Cvar_Get( "r_centerWindow",					"0",						CVAR_ARCHIVE|CVAR_LATCH, "" );
+	r_centerWindow						= ri->Cvar_Get( "r_centerWindow",					"1",						CVAR_ARCHIVE_ND|CVAR_LATCH, "" );
 	r_customwidth						= ri->Cvar_Get( "r_customwidth",					"1600",						CVAR_ARCHIVE|CVAR_LATCH, "" );
 	r_customheight						= ri->Cvar_Get( "r_customheight",					"1024",						CVAR_ARCHIVE|CVAR_LATCH, "" );
 	r_simpleMipMaps						= ri->Cvar_Get( "r_simpleMipMaps",					"1",						CVAR_ARCHIVE_ND|CVAR_LATCH, "" );

--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -47,6 +47,8 @@ cvar_t *r_allowSoftwareGL;
 cvar_t	*r_fullscreen = 0;
 cvar_t	*r_noborder;
 cvar_t	*r_centerWindow;
+cvar_t	*vid_xpos;
+cvar_t	*vid_ypos;
 cvar_t	*r_customwidth;
 cvar_t	*r_customheight;
 cvar_t	*r_swapInterval;
@@ -410,8 +412,11 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 	{
 		x = ( desktopMode.w / 2 ) - ( glConfig->vidWidth / 2 );
 		y = ( desktopMode.h / 2 ) - ( glConfig->vidHeight / 2 );
+	} else {
+		x = vid_xpos->integer;
+		y = vid_ypos->integer;
 	}
-
+	
 	// Destroy existing state if it exists
 	if( opengl_context != NULL )
 	{
@@ -742,7 +747,9 @@ window_t WIN_Init( const windowDesc_t *windowDesc, glconfig_t *glConfig )
 	// Window cvars
 	r_fullscreen		= Cvar_Get( "r_fullscreen",			"1",		CVAR_ARCHIVE|CVAR_LATCH );
 	r_noborder			= Cvar_Get( "r_noborder",			"0",		CVAR_ARCHIVE|CVAR_LATCH );
-	r_centerWindow		= Cvar_Get( "r_centerWindow",		"0",		CVAR_ARCHIVE|CVAR_LATCH );
+	r_centerWindow		= Cvar_Get( "r_centerWindow",		"1",		CVAR_ARCHIVE_ND|CVAR_LATCH );
+	vid_xpos			= Cvar_Get( "vid_xpos",				"3",		CVAR_ARCHIVE_ND|CVAR_LATCH );
+	vid_ypos			= Cvar_Get( "vid_ypos",				"22",		CVAR_ARCHIVE_ND|CVAR_LATCH );
 	r_customwidth		= Cvar_Get( "r_customwidth",		"1440",		CVAR_ARCHIVE|CVAR_LATCH );
 	r_customheight		= Cvar_Get( "r_customheight",		"1080",		CVAR_ARCHIVE|CVAR_LATCH );
 	r_swapInterval		= Cvar_Get( "r_swapInterval",		"0",		CVAR_ARCHIVE_ND );


### PR DESCRIPTION
[ensiform/ETe@2317b84defafdd883b081bac25dfd37d9c5427c1](https://github.com/ensiform/ETe/commit/2317b84defafdd883b081bac25dfd37d9c5427c1)

vid_xypos cvars don't behave exactly like they do in vanilla JAMP, so I defaulted r_centerWindow 1 with nodefault flag, which ignores them.