### PR TITLE
[MP] Merge ioquake/ioq3@b61e299

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-midnight

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -1645,7 +1645,8 @@ void SV_ExecuteClientMessage( client_t *cl, msg_t *msg ) {
 		}
 		// if we can tell that the client has dropped the last
 		// gamestate we sent them, resend it
-		if ( cl->messageAcknowledge > cl->gamestateMessageNum ) {
+        // Fix for https://bugzilla.icculus.org/show_bug.cgi?id=6324
+        if (cl->state != CS_ACTIVE && cl->messageAcknowledge > cl->gamestateMessageNum) {
 			Com_DPrintf( "%s : dropped gamestate, resending\n", cl->name );
 			SV_SendClientGameState( cl );
 		}


### PR DESCRIPTION
Fix exploit to reset player by sending wrong serverId

If client sends wrong serverId but is already active in the world
(CS_ACTIVE) don't resend initial gamestate for the map. This isn't a
valid situation. The player should be CS_CONNECTED or CS_PRIMED.

Resending gamestate to an active player will cause them to respawn
without dying or disconnecting. If the player had a CTF flag it gets
lost until the map is changed or restarted.

Reported by Ensiform at:
    https://bugzilla.icculus.org/show_bug.cgi?id=6324