### PR TITLE
GCC 10 Compliance

### DIFF
--- a/codemp/cgame/cg_consolecmds.c
+++ b/codemp/cgame/cg_consolecmds.c
@@ -1486,6 +1486,8 @@ void CG_SpeedometerSettings_f(void)
 	}
 }
 
+CosmeticUnlocks_t cosmeticUnlocks[MAX_COSMETIC_UNLOCKS];
+
 static bitInfo_T cosmetics[] = {
 	{ "Santa hat" },
 	{ "Jack-o'-lantern" },

--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -1066,7 +1066,7 @@ typedef struct loadableEmoji_s
 	qhandle_t	emoji;
 } loadableEmoji_t;
 
-loadableEmoji_t emojis[MAX_LOADABLE_EMOJIS];
+extern loadableEmoji_t emojis[MAX_LOADABLE_EMOJIS];
 
 typedef struct chatBoxEmoji_s
 {
@@ -2509,7 +2509,7 @@ typedef struct CosmeticUnlocks_s {
 	unsigned int	duration;
 	qboolean		active;
 } CosmeticUnlocks_t;
-CosmeticUnlocks_t cosmeticUnlocks[MAX_COSMETIC_UNLOCKS];
+extern CosmeticUnlocks_t cosmeticUnlocks[MAX_COSMETIC_UNLOCKS];
 //japro
 
 //

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -26,6 +26,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "cg_local.h"
 
 #include "ui/ui_shared.h"
+
+NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+void (*Com_Printf)( const char *msg, ... );
+
 // display context for new ui stuff
 displayContextDef_t cgDC;
 
@@ -2725,6 +2729,8 @@ CG_LoadEmojis
 Method that registers all the avaialable emojis
 =================
 */
+loadableEmoji_t emojis[MAX_LOADABLE_EMOJIS];
+
 static void CG_LoadEmojis(void) {
 	int	emojiExtFNLen, fileCnt, i, inserted = 0;
 	char* holdChar;

--- a/codemp/game/g_account.c
+++ b/codemp/game/g_account.c
@@ -1662,6 +1662,8 @@ void G_UpdateUnlocks(char *username, char *coursename, int style, int duration_m
 	}
 }
 
+CosmeticUnlocks_t cosmeticUnlocks[MAX_COSMETIC_UNLOCKS];
+
 void G_SpawnCosmeticUnlocks(void) {
 	fileHandle_t f;
 	int		fLen = 0, MAX_FILESIZE = 4096, args = 1, row = 0;  //use max num warps idk
@@ -6907,6 +6909,8 @@ void InitGameAccountStuff( void ) { //Called every mapload , move the create tab
 
 	//DebugWriteToDB("InitGameAccountStuff");
 }
+
+Warp_t warpList[64];
 
 void G_SpawnWarpLocationsFromCfg(void) //loda fixme
 {

--- a/codemp/game/g_local.h
+++ b/codemp/game/g_local.h
@@ -1398,7 +1398,7 @@ typedef struct Warp_s {
 	int				z;
 	short			yaw;
 } Warp_t;
-Warp_t	warpList[64];
+extern Warp_t warpList[64];
 //japro
 
 //japro
@@ -1410,7 +1410,7 @@ typedef struct CosmeticUnlocks_s {
 	unsigned int	duration;
 	qboolean		active;
 } CosmeticUnlocks_t;
-CosmeticUnlocks_t cosmeticUnlocks[MAX_COSMETIC_UNLOCKS];
+extern CosmeticUnlocks_t cosmeticUnlocks[MAX_COSMETIC_UNLOCKS];
 //japro
 
 //japro
@@ -1421,7 +1421,7 @@ typedef struct VoteFloodProtect_s {
 	int					nextDropTime;
 } VoteFloodProtect_t;
 #define		voteFloodProtectSize 64
-VoteFloodProtect_t	voteFloodProtect[voteFloodProtectSize];//32 courses, 9 styles, 10 spots on highscore list
+extern VoteFloodProtect_t voteFloodProtect[voteFloodProtectSize]; //32 courses, 9 styles, 10 spots on highscore list
 //japro
 
 typedef struct level_locals_s {

--- a/codemp/game/g_main.c
+++ b/codemp/game/g_main.c
@@ -29,6 +29,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "bg_saga.h"
 #include "b_local.h"
 
+NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+void (*Com_Printf)( const char *msg, ... );
+
 level_locals_t	level;
 
 int		eventClearTime = 0;
@@ -67,6 +70,8 @@ qboolean G_EntIsDoor( int entityNum );
 qboolean G_EntIsBreakable( int entityNum );
 qboolean G_EntIsRemovableUsable( int entNum );
 void CP_FindCombatPointWaypoints( void );
+
+VoteFloodProtect_t voteFloodProtect[voteFloodProtectSize];
 
 /*
 ================

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -693,8 +693,8 @@ qboolean Info_NextPair( const char **s, char *key, char *value );
 
 // this is only here so the functions in q_shared.c and bg_*.c can link
 #if defined( _GAME ) || defined( _CGAME ) || defined( UI_BUILD )
-	NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
-	void (*Com_Printf)( const char *msg, ... );
+	extern NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+	extern void (*Com_Printf)( const char *msg, ... );
 #else
 	void NORETURN QDECL Com_Error( int level, const char *error, ... );
 	void QDECL Com_Printf( const char *msg, ... );

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -44,6 +44,9 @@ USER INTERFACE MAIN
 #include "game/bg_saga.h"
 #include "ui_shared.h"
 
+NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+void (*Com_Printf)( const char *msg, ... );
+
 extern void UI_SaberAttachToChar( itemDef_t *item );
 
 const char *forcepowerDesc[NUM_FORCE_POWERS] =


### PR DESCRIPTION
As of GCC 10, multiple definitions of global variables are rejected and result in compiler errors.