### PR TITLE
Restrict fullscreen mode logic to fullscreen windows

### DIFF
--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -664,7 +664,7 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 
 	SDL_FreeSurface( icon );
 
-	if (!GLimp_DetectAvailableModes())
+	if (fullscreen && !GLimp_DetectAvailableModes())
 	{
 		return RSERR_UNKNOWN;
 	}


### PR DESCRIPTION
Fullscreen logic is incorrectly being applied to windowed instances, artificially and pointlessly limiting supported resolutions.